### PR TITLE
Fixing deprecated hbase API's

### DIFF
--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/AppVersionService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/AppVersionService.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 
 import com.google.common.collect.Lists;
 import com.twitter.hraven.Constants;
+import com.twitter.hraven.util.CellRecords;
 
 /**
  * Reads and writes information about the mapping of application IDs
@@ -63,7 +64,7 @@ public class AppVersionService {
     if (r != null && !r.isEmpty()) {
       for (Cell cell : r.listCells()) {
         versions.add(
-            new VersionInfo(Bytes.toString(cell.getQualifierArray()), Bytes.toLong(cell.getValueArray())) );
+            new VersionInfo(CellRecords.getQualifierString(cell), CellRecords.getValueLong(cell)));
       }
     }
 
@@ -96,9 +97,9 @@ public class AppVersionService {
       for (Cell cell : r.listCells()) {
         ts = 0L;
         try {
-          ts = Bytes.toLong(cell.getValueArray());
+          ts=CellRecords.getValueLong(cell);
           versions.add(
-              new VersionInfo(Bytes.toString(cell.getQualifierArray()), ts) );
+              new VersionInfo(CellRecords.getQualifierString(cell), ts) );
         }
         catch (IllegalArgumentException e1 ) {
           // Bytes.toLong may throw IllegalArgumentException, although unlikely.

--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/AppVersionService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/AppVersionService.java
@@ -61,9 +61,9 @@ public class AppVersionService {
     List<VersionInfo> versions = Lists.newArrayList();
     Result r = this.versionsTable.get(get);
     if (r != null && !r.isEmpty()) {
-      for (Cell kv : r.listCells()) {
+      for (Cell cell : r.listCells()) {
         versions.add(
-            new VersionInfo(Bytes.toString(kv.getQualifierArray()), Bytes.toLong(kv.getValueArray())) );
+            new VersionInfo(Bytes.toString(cell.getQualifierArray()), Bytes.toLong(cell.getValueArray())) );
       }
     }
 
@@ -93,12 +93,12 @@ public class AppVersionService {
     Long ts = 0L;
     Result r = this.versionsTable.get(get);
     if (r != null && !r.isEmpty()) {
-      for (Cell kv : r.listCells()) {
+      for (Cell cell : r.listCells()) {
         ts = 0L;
         try {
-          ts = Bytes.toLong(kv.getValueArray());
+          ts = Bytes.toLong(cell.getValueArray());
           versions.add(
-              new VersionInfo(Bytes.toString(kv.getQualifierArray()), ts) );
+              new VersionInfo(Bytes.toString(cell.getQualifierArray()), ts) );
         }
         catch (IllegalArgumentException e1 ) {
           // Bytes.toLong may throw IllegalArgumentException, although unlikely.

--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/AppVersionService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/AppVersionService.java
@@ -22,13 +22,8 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.KeyValue;
-import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.util.Bytes;
 
 import com.google.common.collect.Lists;
@@ -66,9 +61,9 @@ public class AppVersionService {
     List<VersionInfo> versions = Lists.newArrayList();
     Result r = this.versionsTable.get(get);
     if (r != null && !r.isEmpty()) {
-      for (KeyValue kv : r.list()) {
+      for (Cell kv : r.listCells()) {
         versions.add(
-            new VersionInfo(Bytes.toString(kv.getQualifier()), Bytes.toLong(kv.getValue())) );
+            new VersionInfo(Bytes.toString(kv.getQualifierArray()), Bytes.toLong(kv.getValueArray())) );
       }
     }
 
@@ -98,12 +93,12 @@ public class AppVersionService {
     Long ts = 0L;
     Result r = this.versionsTable.get(get);
     if (r != null && !r.isEmpty()) {
-      for (KeyValue kv : r.list()) {
+      for (Cell kv : r.listCells()) {
         ts = 0L;
         try {
-          ts = Bytes.toLong(kv.getValue());
+          ts = Bytes.toLong(kv.getValueArray());
           versions.add(
-              new VersionInfo(Bytes.toString(kv.getQualifier()), ts) );
+              new VersionInfo(Bytes.toString(kv.getQualifierArray()), ts) );
         }
         catch (IllegalArgumentException e1 ) {
           // Bytes.toLong may throw IllegalArgumentException, although unlikely.

--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/FlowQueueService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/FlowQueueService.java
@@ -31,6 +31,7 @@ import com.twitter.hraven.FlowKey;
 import com.twitter.hraven.FlowQueueKey;
 import com.twitter.hraven.rest.PaginatedResult;
 import com.twitter.hraven.util.ByteUtil;
+import com.twitter.hraven.util.CellRecords;
 
 /**
  */
@@ -80,7 +81,7 @@ public class FlowQueueService {
     // copy the existing row to the new key
     Put p = new Put(queueKeyConverter.toBytes(newKey));
     for (Cell cell : result.rawCells()) {
-      p.add(cell.getFamilyArray(), cell.getQualifierArray(), cell.getValueArray());
+      p.add(CellRecords.getFamilyBytes(cell), CellRecords.getQualifierBytes(cell), CellRecords.getValueBytes(cell));
     }
     flowQueueTable.put(p);
     // delete the old row

--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/FlowQueueService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/FlowQueueService.java
@@ -79,8 +79,8 @@ public class FlowQueueService {
     }
     // copy the existing row to the new key
     Put p = new Put(queueKeyConverter.toBytes(newKey));
-    for (Cell kv : result.rawCells()) {
-      p.add(kv.getFamilyArray(), kv.getQualifierArray(), kv.getValueArray());
+    for (Cell cell : result.rawCells()) {
+      p.add(cell.getFamilyArray(), cell.getQualifierArray(), cell.getValueArray());
     }
     flowQueueTable.put(p);
     // delete the old row

--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/FlowQueueService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/FlowQueueService.java
@@ -15,32 +15,22 @@ limitations under the License.
 */
 package com.twitter.hraven.datasource;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.filter.*;
+import org.apache.hadoop.hbase.util.Bytes;
+
 import com.twitter.hraven.Constants;
 import com.twitter.hraven.Flow;
 import com.twitter.hraven.FlowKey;
 import com.twitter.hraven.FlowQueueKey;
 import com.twitter.hraven.rest.PaginatedResult;
 import com.twitter.hraven.util.ByteUtil;
-
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.KeyValue;
-import org.apache.hadoop.hbase.client.Delete;
-import org.apache.hadoop.hbase.client.Get;
-import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.filter.CompareFilter;
-import org.apache.hadoop.hbase.filter.FilterList;
-import org.apache.hadoop.hbase.filter.PrefixFilter;
-import org.apache.hadoop.hbase.filter.SingleColumnValueFilter;
-import org.apache.hadoop.hbase.filter.WhileMatchFilter;
-import org.apache.hadoop.hbase.util.Bytes;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  */
@@ -89,8 +79,8 @@ public class FlowQueueService {
     }
     // copy the existing row to the new key
     Put p = new Put(queueKeyConverter.toBytes(newKey));
-    for (KeyValue kv : result.raw()) {
-      p.add(kv.getFamily(), kv.getQualifier(), kv.getValue());
+    for (Cell kv : result.rawCells()) {
+      p.add(kv.getFamilyArray(), kv.getQualifierArray(), kv.getValueArray());
     }
     flowQueueTable.put(p);
     // delete the old row

--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/JobHistoryRawService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/JobHistoryRawService.java
@@ -27,7 +27,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
-import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.filter.CompareFilter;
 import org.apache.hadoop.hbase.filter.FilterList;
@@ -42,6 +41,7 @@ import com.twitter.hraven.JobId;
 import com.twitter.hraven.QualifiedJobId;
 import com.twitter.hraven.Range;
 import com.twitter.hraven.util.BatchUtil;
+import com.twitter.hraven.util.CellRecords;
 
 /**
  * Used to store and retrieve {@link ProcessRecord} objects.
@@ -365,7 +365,7 @@ public class JobHistoryRawService {
 
     byte[] jobConfRawBytes = null;
     if (cell != null) {
-      jobConfRawBytes = cell.getValueArray();
+      jobConfRawBytes = CellRecords.getValueBytes(cell);
     }
     if (jobConfRawBytes == null || jobConfRawBytes.length == 0) {
       throw new MissingColumnInResultException(Constants.RAW_FAM_BYTES,
@@ -493,10 +493,9 @@ public class JobHistoryRawService {
           Constants.JOBHISTORY_LAST_MODIFIED_COL_BYTES);
     }
 
-    byte[] lastModTimeBytes = cell.getValueArray();
     // we try to approximately set the job submit time based on when the job history file
     // was last modified and an average job duration
-    long lastModTime = Bytes.toLong(lastModTimeBytes);
+    long lastModTime = CellRecords.getValueLong(cell);
     long jobSubmitTimeMillis = lastModTime - Constants.AVERGAE_JOB_DURATION;
     LOG.debug("Approximate job submit time is " + jobSubmitTimeMillis + " based on " + lastModTime);
     return jobSubmitTimeMillis;
@@ -517,7 +516,7 @@ public class JobHistoryRawService {
 
   /**
    * Flags a job's RAW record for reprocessing
-   * 
+   *
    * @param jobId
    */
   public void markJobForReprocesssing(QualifiedJobId jobId) throws IOException {
@@ -549,7 +548,7 @@ public class JobHistoryRawService {
           Constants.JOBHISTORY_COL_BYTES);
     }
 
-    byte[] jobHistoryRaw = cell.getValueArray();
+    byte[] jobHistoryRaw = CellRecords.getValueBytes(cell);
     return jobHistoryRaw;
   }
 

--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/JobHistoryRawService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/JobHistoryRawService.java
@@ -26,6 +26,7 @@ import java.util.TreeSet;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.filter.CompareFilter;
@@ -356,15 +357,15 @@ public class JobHistoryRawService {
       throw new IllegalArgumentException("Cannot create InputStream from null");
     }
 
-    KeyValue keyValue = result.getColumnLatest(Constants.RAW_FAM_BYTES,
-        Constants.JOBCONF_COL_BYTES);
+    Cell keyValue = result.getColumnLatestCell(Constants.RAW_FAM_BYTES,
+                                               Constants.JOBCONF_COL_BYTES);
 
     // Create a jobConf from the raw input
     Configuration jobConf = new Configuration(false);
 
     byte[] jobConfRawBytes = null;
     if (keyValue != null) {
-      jobConfRawBytes = keyValue.getValue();
+      jobConfRawBytes = keyValue.getValueArray();
     }
     if (jobConfRawBytes == null || jobConfRawBytes.length == 0) {
       throw new MissingColumnInResultException(Constants.RAW_FAM_BYTES,
@@ -484,15 +485,15 @@ public class JobHistoryRawService {
           + "a null hbase result");
     }
 
-    KeyValue keyValue = value.getColumnLatest(Constants.INFO_FAM_BYTES,
-          Constants.JOBHISTORY_LAST_MODIFIED_COL_BYTES);
+    Cell keyValue = value.getColumnLatestCell(Constants.INFO_FAM_BYTES,
+                                              Constants.JOBHISTORY_LAST_MODIFIED_COL_BYTES);
 
     if (keyValue == null) {
       throw new MissingColumnInResultException(Constants.INFO_FAM_BYTES,
           Constants.JOBHISTORY_LAST_MODIFIED_COL_BYTES);
     }
 
-    byte[] lastModTimeBytes = keyValue.getValue();
+    byte[] lastModTimeBytes = keyValue.getValueArray();
     // we try to approximately set the job submit time based on when the job history file
     // was last modified and an average job duration
     long lastModTime = Bytes.toLong(lastModTimeBytes);
@@ -539,8 +540,8 @@ public class JobHistoryRawService {
       throw new IllegalArgumentException("Cannot create InputStream from null");
     }
     
-    KeyValue keyValue =
-        value.getColumnLatest(Constants.RAW_FAM_BYTES, Constants.JOBHISTORY_COL_BYTES);
+    Cell keyValue =
+        value.getColumnLatestCell(Constants.RAW_FAM_BYTES, Constants.JOBHISTORY_COL_BYTES);
 
     // Could be that there is no conf file (only a history file).
     if (keyValue == null) {
@@ -548,7 +549,7 @@ public class JobHistoryRawService {
           Constants.JOBHISTORY_COL_BYTES);
     }
 
-    byte[] jobHistoryRaw = keyValue.getValue();
+    byte[] jobHistoryRaw = keyValue.getValueArray();
     return jobHistoryRaw;
   }
 

--- a/hraven-core/src/main/java/com/twitter/hraven/datasource/JobHistoryRawService.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/datasource/JobHistoryRawService.java
@@ -357,15 +357,15 @@ public class JobHistoryRawService {
       throw new IllegalArgumentException("Cannot create InputStream from null");
     }
 
-    Cell keyValue = result.getColumnLatestCell(Constants.RAW_FAM_BYTES,
+    Cell cell = result.getColumnLatestCell(Constants.RAW_FAM_BYTES,
                                                Constants.JOBCONF_COL_BYTES);
 
     // Create a jobConf from the raw input
     Configuration jobConf = new Configuration(false);
 
     byte[] jobConfRawBytes = null;
-    if (keyValue != null) {
-      jobConfRawBytes = keyValue.getValueArray();
+    if (cell != null) {
+      jobConfRawBytes = cell.getValueArray();
     }
     if (jobConfRawBytes == null || jobConfRawBytes.length == 0) {
       throw new MissingColumnInResultException(Constants.RAW_FAM_BYTES,
@@ -485,15 +485,15 @@ public class JobHistoryRawService {
           + "a null hbase result");
     }
 
-    Cell keyValue = value.getColumnLatestCell(Constants.INFO_FAM_BYTES,
+    Cell cell = value.getColumnLatestCell(Constants.INFO_FAM_BYTES,
                                               Constants.JOBHISTORY_LAST_MODIFIED_COL_BYTES);
 
-    if (keyValue == null) {
+    if (cell == null) {
       throw new MissingColumnInResultException(Constants.INFO_FAM_BYTES,
           Constants.JOBHISTORY_LAST_MODIFIED_COL_BYTES);
     }
 
-    byte[] lastModTimeBytes = keyValue.getValueArray();
+    byte[] lastModTimeBytes = cell.getValueArray();
     // we try to approximately set the job submit time based on when the job history file
     // was last modified and an average job duration
     long lastModTime = Bytes.toLong(lastModTimeBytes);
@@ -540,16 +540,16 @@ public class JobHistoryRawService {
       throw new IllegalArgumentException("Cannot create InputStream from null");
     }
     
-    Cell keyValue =
+    Cell cell =
         value.getColumnLatestCell(Constants.RAW_FAM_BYTES, Constants.JOBHISTORY_COL_BYTES);
 
     // Could be that there is no conf file (only a history file).
-    if (keyValue == null) {
+    if (cell == null) {
       throw new MissingColumnInResultException(Constants.RAW_FAM_BYTES,
           Constants.JOBHISTORY_COL_BYTES);
     }
 
-    byte[] jobHistoryRaw = keyValue.getValueArray();
+    byte[] jobHistoryRaw = cell.getValueArray();
     return jobHistoryRaw;
   }
 

--- a/hraven-core/src/main/java/com/twitter/hraven/util/CellRecords.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/util/CellRecords.java
@@ -1,0 +1,39 @@
+package com.twitter.hraven.util;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.util.Bytes;
+
+public class CellRecords {
+
+    public static byte[] getValueBytes(Cell cell){
+        byte[] cellValueBytes = Bytes.copy(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength());
+        return cellValueBytes;
+    }
+
+    public static long getValueLong(Cell cell){
+        return Bytes.toLong(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength());
+    }
+
+    public static int getValueInt(Cell cell){
+        return Bytes.toInt(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength());
+    }
+
+    public static String getValueString(Cell cell){
+        return Bytes.toString(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength());
+    }
+
+    public static byte[] getFamilyBytes(Cell cell){
+        byte[] cellFamilyBytes = Bytes.copy(cell.getFamilyArray(), cell.getFamilyOffset(), cell.getFamilyLength());
+        return cellFamilyBytes;
+    }
+
+    public static byte[] getQualifierBytes(Cell cell){
+        byte[] cellQualifierBytes = Bytes.copy(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
+        return cellQualifierBytes;
+    }
+
+    public static String getQualifierString(Cell cell){
+        return Bytes.toString(cell.getQualifierArray(), cell.getQualifierOffset(), cell.getQualifierLength());
+
+    }
+}

--- a/hraven-core/src/main/java/com/twitter/hraven/util/FuzzyRowFilter.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/util/FuzzyRowFilter.java
@@ -75,7 +75,7 @@ public class FuzzyRowFilter extends FilterBase {
   // TODO: possible improvement: save which fuzzy row key to use when providing a hint
   @Override
   public ReturnCode filterKeyValue(Cell kv) {
-    byte[] rowKey = kv.getRow();
+    byte[] rowKey = kv.getRowArray();
     // assigning "worst" result first and looking for better options
     SatisfiesCode bestOption = SatisfiesCode.NO_NEXT;
     for (Pair<byte[], byte[]> fuzzyData : fuzzyKeysData) {
@@ -101,7 +101,7 @@ public class FuzzyRowFilter extends FilterBase {
 
   @Override
   public KeyValue getNextKeyHint(KeyValue currentKV) {
-    byte[] rowKey = currentKV.getRow();
+    byte[] rowKey = currentKV.getRowArray();
     byte[] nextRowKey = null;
     // Searching for the "smallest" row key that satisfies at least one fuzzy row key
     for (Pair<byte[], byte[]> fuzzyData : fuzzyKeysData) {

--- a/hraven-core/src/main/java/com/twitter/hraven/util/FuzzyRowFilter.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/util/FuzzyRowFilter.java
@@ -75,7 +75,7 @@ public class FuzzyRowFilter extends FilterBase {
   // TODO: possible improvement: save which fuzzy row key to use when providing a hint
   @Override
   public ReturnCode filterKeyValue(Cell cell) {
-    byte[] rowKey = cell.getRowArray();
+    byte[] rowKey = Bytes.copy(cell.getRowArray(), cell.getRowOffset(),cell.getRowLength());
     // assigning "worst" result first and looking for better options
     SatisfiesCode bestOption = SatisfiesCode.NO_NEXT;
     for (Pair<byte[], byte[]> fuzzyData : fuzzyKeysData) {
@@ -101,7 +101,7 @@ public class FuzzyRowFilter extends FilterBase {
 
   @Override
   public KeyValue getNextKeyHint(KeyValue currentKV) {
-    byte[] rowKey = currentKV.getRowArray();
+    byte[] rowKey = Bytes.copy(currentKV.getRowArray(),currentKV.getRowOffset(),currentKV.getRowLength());
     byte[] nextRowKey = null;
     // Searching for the "smallest" row key that satisfies at least one fuzzy row key
     for (Pair<byte[], byte[]> fuzzyData : fuzzyKeysData) {

--- a/hraven-core/src/main/java/com/twitter/hraven/util/FuzzyRowFilter.java
+++ b/hraven-core/src/main/java/com/twitter/hraven/util/FuzzyRowFilter.java
@@ -74,8 +74,8 @@ public class FuzzyRowFilter extends FilterBase {
 
   // TODO: possible improvement: save which fuzzy row key to use when providing a hint
   @Override
-  public ReturnCode filterKeyValue(Cell kv) {
-    byte[] rowKey = kv.getRowArray();
+  public ReturnCode filterKeyValue(Cell cell) {
+    byte[] rowKey = cell.getRowArray();
     // assigning "worst" result first and looking for better options
     SatisfiesCode bestOption = SatisfiesCode.NO_NEXT;
     for (Pair<byte[], byte[]> fuzzyData : fuzzyKeysData) {

--- a/hraven-core/src/test/java/com/twitter/hraven/datasource/TestAppVersionService.java
+++ b/hraven-core/src/test/java/com/twitter/hraven/datasource/TestAppVersionService.java
@@ -15,10 +15,10 @@ limitations under the License.
 */
 package com.twitter.hraven.datasource;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashSet;
 import java.util.List;
@@ -34,8 +34,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.twitter.hraven.Constants;
-import com.twitter.hraven.datasource.AppVersionService;
-import com.twitter.hraven.datasource.VersionInfo;
 
 /**
  * Test class for {@link AppVersionService}
@@ -72,7 +70,7 @@ public class TestAppVersionService {
       Result r = versionTable.get(new Get(appRow));
       assertNotNull(r);
       // should have 1 version
-      assertEquals(r.list().size(), 1);
+      assertEquals(r.listCells().size(), 1);
       assertArrayEquals(
           r.getValue(Constants.INFO_FAM_BYTES, Bytes.toBytes("v1")),
           Bytes.toBytes(1L));
@@ -80,7 +78,7 @@ public class TestAppVersionService {
       service.addVersion(cluster, user, appId, "v2", 10);
       r = versionTable.get(new Get(appRow));
       assertNotNull(r);
-      assertEquals(r.list().size(), 2);
+      assertEquals(r.listCells().size(), 2);
       assertArrayEquals(
           r.getValue(Constants.INFO_FAM_BYTES, Bytes.toBytes("v1")),
           Bytes.toBytes(1L));
@@ -92,7 +90,7 @@ public class TestAppVersionService {
       service.addVersion(cluster, user, appId, "v2", 5);
       r = versionTable.get(new Get(appRow));
       assertNotNull(r);
-      assertEquals(r.list().size(), 2);
+      assertEquals(r.listCells().size(), 2);
       assertArrayEquals(
           r.getValue(Constants.INFO_FAM_BYTES, Bytes.toBytes("v2")),
           Bytes.toBytes(5L));
@@ -101,7 +99,7 @@ public class TestAppVersionService {
       service.addVersion(cluster, user, appId, "v1", 11);
       r = versionTable.get(new Get(appRow));
       assertNotNull(r);
-      assertEquals(r.list().size(), 2);
+      assertEquals(r.listCells().size(), 2);
       assertArrayEquals(
           r.getValue(Constants.INFO_FAM_BYTES, Bytes.toBytes("v1")),
           Bytes.toBytes(1L));

--- a/hraven-core/src/test/java/com/twitter/hraven/datasource/TestFlowQueueService.java
+++ b/hraven-core/src/test/java/com/twitter/hraven/datasource/TestFlowQueueService.java
@@ -15,11 +15,13 @@ limitations under the License.
 */
 package com.twitter.hraven.datasource;
 
-import com.twitter.hraven.Flow;
-import com.twitter.hraven.FlowQueueKey;
-import com.twitter.hraven.datasource.FlowQueueService;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-import com.twitter.hraven.rest.PaginatedResult;
+import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
@@ -27,9 +29,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.List;
-
-import static org.junit.Assert.*;
+import com.twitter.hraven.Flow;
+import com.twitter.hraven.FlowQueueKey;
+import com.twitter.hraven.rest.PaginatedResult;
 
 /**
  */
@@ -83,6 +85,8 @@ public class TestFlowQueueService {
     FlowQueueKey newKey1 = new FlowQueueKey(key1.getCluster(), Flow.Status.SUCCEEDED,
         key1.getTimestamp(), key1.getFlowId());
     service.moveFlow(key1, newKey1);
+      System.out.println("key1 = " + key1);
+      System.out.println("newkey1 = " + newKey1);
     FlowQueueKey newKey2 = new FlowQueueKey(key2.getCluster(), Flow.Status.SUCCEEDED,
         key2.getTimestamp(), key2.getFlowId());
     service.moveFlow(key2, newKey2);

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/FileLister.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/FileLister.java
@@ -57,7 +57,7 @@ public class FileLister {
     // get all the files and dirs in the current dir
     FileStatus allFiles[] = hdfs.listStatus(inputPath);
     for (FileStatus aFile: allFiles) {
-      if (aFile.isDir()) {
+      if (aFile.isDirectory()) {
         //recurse here
         traverseDirs(fileStatusesList, hdfs, aFile.getPath(), jobFileModifiedRangePathFilter);
       }

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFilePartitioner.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFilePartitioner.java
@@ -246,7 +246,7 @@ public class JobFilePartitioner extends Configured implements Tool {
     outputPath = new Path(output);
     FileStatus outputFileStatus = hdfs.getFileStatus(outputPath);
 
-    if (!outputFileStatus.isDir()) {
+    if (!outputFileStatus.isDirectory()) {
       throw new IOException("Output is not a directory"
           + outputFileStatus.getPath().getName());
     }
@@ -310,7 +310,7 @@ public class JobFilePartitioner extends Configured implements Tool {
     FileStatus inputFileStatus = hdfs.getFileStatus(inputPath);
 
     // Check if input is a directory
-    if (!inputFileStatus.isDir()) {
+    if (!inputFileStatus.isDirectory()) {
       throw new IOException("Input is not a directory in HDFS: " + input);
     }
 

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFilePreprocessor.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/JobFilePreprocessor.java
@@ -19,15 +19,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Option;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
+import org.apache.commons.cli.*;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -39,7 +32,6 @@ import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.io.SequenceFile.Writer;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
@@ -48,11 +40,7 @@ import org.apache.log4j.Logger;
 
 import com.twitter.hraven.Constants;
 import com.twitter.hraven.datasource.ProcessingException;
-import com.twitter.hraven.etl.ProcessRecordService;
 import com.twitter.hraven.util.BatchUtil;
-import com.twitter.hraven.etl.FileLister;
-import com.twitter.hraven.etl.JobFileModifiedRangeSubstringPathFilter;
-import sun.text.resources.FormatData_iw_IL;
 
 /**
  * Command line tool that can be run on a periodic basis (like daily, hourly, or
@@ -328,7 +316,7 @@ public class JobFilePreprocessor extends Configured implements Tool {
     Path baseInputPath = new Path(baseinput);
     FileStatus baseInputFileStatus = hdfs.getFileStatus(baseInputPath);
 
-    if (!baseInputFileStatus.isDir()) {
+    if (!baseInputFileStatus.isDirectory()) {
       throw new IOException("Base input is not a directory"
           + baseInputFileStatus.getPath().getName());
     }

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.io.SequenceFile.Writer;
 
 import com.twitter.hraven.Constants;
 import com.twitter.hraven.datasource.ProcessingException;
+import com.twitter.hraven.util.CellRecords;
 
 /**
  * Used to store and retrieve {@link ProcessRecord} objects.
@@ -299,33 +300,32 @@ public class ProcessRecordService {
 
       Cell cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
                                                  Constants.MIN_MOD_TIME_MILLIS_COLUMN_BYTES);
-      long minModificationTimeMillis = Bytes.toLong(cell.getValueArray());
+      long minModificationTimeMillis = CellRecords.getValueLong(cell);
 
       cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.PROCESSED_JOB_FILES_COLUMN_BYTES);
-      int processedJobFiles = Bytes.toInt(cell.getValueArray());
+      int processedJobFiles = CellRecords.getValueInt(cell);
 
       cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.PROCESS_FILE_COLUMN_BYTES);
-      String processingDirectory = Bytes.toString(cell.getValueArray());
+      String processingDirectory = CellRecords.getValueString(cell);
 
       cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.PROCESSING_STATE_COLUMN_BYTES);
-      ProcessState processState = ProcessState.getProcessState(Bytes
-          .toInt(cell.getValueArray()));
+      ProcessState processState = ProcessState.getProcessState(CellRecords.getValueInt(cell));
 
       cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.MIN_JOB_ID_COLUMN_BYTES);
       String minJobId = null;
       if (cell != null) {
-        minJobId = Bytes.toString(cell.getValueArray());
+        minJobId = CellRecords.getValueString(cell);
       }
 
       cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.MAX_JOB_ID_COLUMN_BYTES);
       String maxJobId = null;
       if (cell != null) {
-        maxJobId = Bytes.toString(cell.getValueArray());
+        maxJobId = CellRecords.getValueString(cell);
       }
 
       ProcessRecord processRecord = new ProcessRecord(key.getCluster(),

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
@@ -33,12 +33,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.KeyValue;
-import org.apache.hadoop.hbase.client.HTable;
-import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
-import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.filter.CompareFilter.CompareOp;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.FilterList;
@@ -50,10 +46,6 @@ import org.apache.hadoop.io.SequenceFile.Writer;
 
 import com.twitter.hraven.Constants;
 import com.twitter.hraven.datasource.ProcessingException;
-import com.twitter.hraven.etl.JobFile;
-import com.twitter.hraven.etl.ProcessRecord;
-import com.twitter.hraven.etl.ProcessRecordKey;
-import com.twitter.hraven.etl.ProcessState;
 
 /**
  * Used to store and retrieve {@link ProcessRecord} objects.
@@ -305,35 +297,35 @@ public class ProcessRecordService {
       byte[] row = result.getRow();
       ProcessRecordKey key = keyConv.fromBytes(row);
 
-      KeyValue keyValue = result.getColumnLatest(Constants.INFO_FAM_BYTES,
-          Constants.MIN_MOD_TIME_MILLIS_COLUMN_BYTES);
-      long minModificationTimeMillis = Bytes.toLong(keyValue.getValue());
+      Cell keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
+                                                 Constants.MIN_MOD_TIME_MILLIS_COLUMN_BYTES);
+      long minModificationTimeMillis = Bytes.toLong(keyValue.getValueArray());
 
-      keyValue = result.getColumnLatest(Constants.INFO_FAM_BYTES,
+      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.PROCESSED_JOB_FILES_COLUMN_BYTES);
-      int processedJobFiles = Bytes.toInt(keyValue.getValue());
+      int processedJobFiles = Bytes.toInt(keyValue.getValueArray());
 
-      keyValue = result.getColumnLatest(Constants.INFO_FAM_BYTES,
+      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.PROCESS_FILE_COLUMN_BYTES);
-      String processingDirectory = Bytes.toString(keyValue.getValue());
+      String processingDirectory = Bytes.toString(keyValue.getValueArray());
 
-      keyValue = result.getColumnLatest(Constants.INFO_FAM_BYTES,
+      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.PROCESSING_STATE_COLUMN_BYTES);
       ProcessState processState = ProcessState.getProcessState(Bytes
-          .toInt(keyValue.getValue()));
+          .toInt(keyValue.getValueArray()));
 
-      keyValue = result.getColumnLatest(Constants.INFO_FAM_BYTES,
+      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.MIN_JOB_ID_COLUMN_BYTES);
       String minJobId = null;
       if (keyValue != null) {
-        minJobId = Bytes.toString(keyValue.getValue());
+        minJobId = Bytes.toString(keyValue.getValueArray());
       }
 
-      keyValue = result.getColumnLatest(Constants.INFO_FAM_BYTES,
+      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.MAX_JOB_ID_COLUMN_BYTES);
       String maxJobId = null;
       if (keyValue != null) {
-        maxJobId = Bytes.toString(keyValue.getValue());
+        maxJobId = Bytes.toString(keyValue.getValueArray());
       }
 
       ProcessRecord processRecord = new ProcessRecord(key.getCluster(),

--- a/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/etl/ProcessRecordService.java
@@ -297,35 +297,35 @@ public class ProcessRecordService {
       byte[] row = result.getRow();
       ProcessRecordKey key = keyConv.fromBytes(row);
 
-      Cell keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
+      Cell cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
                                                  Constants.MIN_MOD_TIME_MILLIS_COLUMN_BYTES);
-      long minModificationTimeMillis = Bytes.toLong(keyValue.getValueArray());
+      long minModificationTimeMillis = Bytes.toLong(cell.getValueArray());
 
-      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
+      cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.PROCESSED_JOB_FILES_COLUMN_BYTES);
-      int processedJobFiles = Bytes.toInt(keyValue.getValueArray());
+      int processedJobFiles = Bytes.toInt(cell.getValueArray());
 
-      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
+      cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.PROCESS_FILE_COLUMN_BYTES);
-      String processingDirectory = Bytes.toString(keyValue.getValueArray());
+      String processingDirectory = Bytes.toString(cell.getValueArray());
 
-      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
+      cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.PROCESSING_STATE_COLUMN_BYTES);
       ProcessState processState = ProcessState.getProcessState(Bytes
-          .toInt(keyValue.getValueArray()));
+          .toInt(cell.getValueArray()));
 
-      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
+      cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.MIN_JOB_ID_COLUMN_BYTES);
       String minJobId = null;
-      if (keyValue != null) {
-        minJobId = Bytes.toString(keyValue.getValueArray());
+      if (cell != null) {
+        minJobId = Bytes.toString(cell.getValueArray());
       }
 
-      keyValue = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
+      cell = result.getColumnLatestCell(Constants.INFO_FAM_BYTES,
           Constants.MAX_JOB_ID_COLUMN_BYTES);
       String maxJobId = null;
-      if (keyValue != null) {
-        maxJobId = Bytes.toString(keyValue.getValueArray());
+      if (cell != null) {
+        maxJobId = Bytes.toString(cell.getValueArray());
       }
 
       ProcessRecord processRecord = new ProcessRecord(key.getCluster(),

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/GraphiteOutputFormat.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/GraphiteOutputFormat.java
@@ -110,10 +110,10 @@ public class GraphiteOutputFormat extends OutputFormat<EnumWritable<HravenServic
       this.metricNamingRules = metricNamingRules;
       
       keyMappingTable = new HTable(hbaseconfig, Constants.GRAPHITE_KEY_MAPPING_TABLE_BYTES);
-      keyMappingTable.setAutoFlush(false);
+      keyMappingTable.setAutoFlushTo(false);
 
       reverseKeyMappingTable = new HTable(hbaseconfig, Constants.GRAPHITE_REVERSE_KEY_MAPPING_TABLE_BYTES);
-      reverseKeyMappingTable.setAutoFlush(false);
+      reverseKeyMappingTable.setAutoFlushTo(false);
 
       try {
         // Open an connection to Graphite server.

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobFileTableMapper.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobFileTableMapper.java
@@ -239,14 +239,14 @@ public class JobFileTableMapper extends
        * **/
       
       //3.1: get job history
-      Cell keyValue = value.getColumnLatestCell(Constants.RAW_FAM_BYTES, Constants.JOBHISTORY_COL_BYTES);
+      Cell cell = value.getColumnLatestCell(Constants.RAW_FAM_BYTES, Constants.JOBHISTORY_COL_BYTES);
 
       byte[] historyFileContents = null;
-      if (keyValue == null) {
+      if (cell == null) {
         throw new MissingColumnInResultException(Constants.RAW_FAM_BYTES,
           Constants.JOBHISTORY_COL_BYTES);
       } else {
-        historyFileContents = keyValue.getValueArray();
+        historyFileContents = cell.getValueArray();
       }
       
       //3.2: parse job history

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobFileTableMapper.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobFileTableMapper.java
@@ -31,7 +31,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.filecache.DistributedCache;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
@@ -41,31 +41,9 @@ import org.apache.hadoop.mapreduce.lib.output.MultipleOutputs;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
-import com.twitter.hraven.Constants;
-import com.twitter.hraven.HravenRecord;
-import com.twitter.hraven.HravenService;
-import com.twitter.hraven.JobDesc;
-import com.twitter.hraven.JobDescFactory;
-import com.twitter.hraven.JobHistoryRecordCollection;
-import com.twitter.hraven.JobHistoryRecord;
-import com.twitter.hraven.JobHistoryTaskRecord;
-import com.twitter.hraven.JobKey;
-import com.twitter.hraven.QualifiedJobId;
-import com.twitter.hraven.RecordCategory;
-import com.twitter.hraven.RecordDataKey;
-import com.twitter.hraven.datasource.AppVersionService;
-import com.twitter.hraven.datasource.JobHistoryByIdService;
-import com.twitter.hraven.datasource.JobHistoryRawService;
-import com.twitter.hraven.datasource.JobHistoryService;
-import com.twitter.hraven.datasource.JobKeyConverter;
-import com.twitter.hraven.datasource.MissingColumnInResultException;
-import com.twitter.hraven.datasource.ProcessingException;
-import com.twitter.hraven.datasource.RowKeyParseException;
-import com.twitter.hraven.etl.JobHistoryFileParser;
-import com.twitter.hraven.etl.JobHistoryFileParserBase;
-import com.twitter.hraven.etl.JobHistoryFileParserFactory;
-import com.twitter.hraven.etl.ProcessRecordService;
-import com.twitter.hraven.etl.Sink;
+import com.twitter.hraven.*;
+import com.twitter.hraven.datasource.*;
+import com.twitter.hraven.etl.*;
 import com.twitter.hraven.util.EnumWritable;
 
 /**
@@ -261,15 +239,14 @@ public class JobFileTableMapper extends
        * **/
       
       //3.1: get job history
-      KeyValue keyValue = value.getColumnLatest(Constants.RAW_FAM_BYTES,
-       Constants.JOBHISTORY_COL_BYTES);
+      Cell keyValue = value.getColumnLatestCell(Constants.RAW_FAM_BYTES, Constants.JOBHISTORY_COL_BYTES);
 
       byte[] historyFileContents = null;
       if (keyValue == null) {
         throw new MissingColumnInResultException(Constants.RAW_FAM_BYTES,
           Constants.JOBHISTORY_COL_BYTES);
       } else {
-        historyFileContents = keyValue.getValue();
+        historyFileContents = keyValue.getValueArray();
       }
       
       //3.2: parse job history

--- a/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobFileTableMapper.java
+++ b/hraven-etl/src/main/java/com/twitter/hraven/mapreduce/JobFileTableMapper.java
@@ -44,6 +44,7 @@ import com.google.common.collect.Collections2;
 import com.twitter.hraven.*;
 import com.twitter.hraven.datasource.*;
 import com.twitter.hraven.etl.*;
+import com.twitter.hraven.util.CellRecords;
 import com.twitter.hraven.util.EnumWritable;
 
 /**
@@ -246,7 +247,7 @@ public class JobFileTableMapper extends
         throw new MissingColumnInResultException(Constants.RAW_FAM_BYTES,
           Constants.JOBHISTORY_COL_BYTES);
       } else {
-        historyFileContents = cell.getValueArray();
+        historyFileContents = CellRecords.getValueBytes(cell);
       }
       
       //3.2: parse job history

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,7 @@
             </build>
         </profile>
         <profile>
+            <!-- This profile is for hadoop2 and not cdh4. -->
             <id>cdh4</id>
             <activation>
                 <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
API changes summary:

kv.getQualifier -> CellRecord.getQualifier_(cell)
kv.getValue -> CellRecord.getValue_(cell)
kv.getRow -> kv.getRowArray
kv.getFamily() -> CellRecord.getFamily*(cell)
KeyValue kv : result.raw -> KeyValue kv : result.rawCells
KeyValue kv : r.list() -> KeyValue kv : r.listCells()
KeyValue keyValue = value.getColumnLatest -> KeyValue keyValue = value.getColumnLatestCell
keyMappingTable.setAutoFlush -> keyMappingTable.setAutoFlushTo
isDir -> isDirectory
